### PR TITLE
Proposal to change two links of two speakers at event #9

### DIFF
--- a/app/models/Events.php
+++ b/app/models/Events.php
@@ -420,7 +420,7 @@ class Events extends Base
                     'description'               => '...aka "Przetwarzanie strumieni danych real-time ze Storm". Świat BigData niemal w całości zdominowany jest przez ekosystem Apache Hadoop i rozwiązania bazujące na JVM. Batchowa charakterystyka Hadoopa nie pozwala go użyć bezpośrednio w systemach real-time, ale na szczęście istnieją narzędzia typu Storm, eliminujące tę lukę. Dodatkowo pozwalają one użyć w szerszym niż Hadoop kontekście innych technologii do przetwarzania danych, w tym także PHP. O czym będzie więc ta prezentacja? O strumieniach danych, topologiach ich przetwarzania, sproutach, boltach, skalowalności, odporności na błędy, realnych zastosowaniach i całej reszcie "burzowej" otoczki… Nie znasz Storma? Nie szkodzi, Twitter też go nie znał, a uczynił z niego jedno z głównych narzędzi do analizy real-time naszych feedów i wykrywania trendów.',
                     'speaker_name'              => 'Mariusz Gil',
                     'speaker_avatar'            => 'http://0.gravatar.com/avatar/34be88398f623c109b61d23e8215bd23',
-                    'speaker_www'               => 'https://twitter.com/mariuszgil',
+                    'speaker_www'               => 'http://mariuszgil.pl/',
                     'slides_link'               => null,
                     'skill_level'               => 4,
                     'video'                     => null


### PR DESCRIPTION
Przeglądałem dzisiaj stronkę spotkania nr 9 i zauważyłem, że jeden link "nie działa". A drugi prowadzi do podstrony nazwa.pl z tekstem:

> **mariuszgil.pl**
> Domena jest utrzymywana na serwerach nazwa.pl

gdzie po chwili następuje przekierowanie do nazwa.pl. "Zafixowałem" to szybko. Jeśli nie macie nic przeciwko i prelegenci nie mają nic przeciwko, to merge'ujcie ;)
